### PR TITLE
CorbinFisher.yml- scrape remaster/re-release tag based on url

### DIFF
--- a/scrapers/CorbinFisher.yml
+++ b/scrapers/CorbinFisher.yml
@@ -38,6 +38,17 @@ xPathScrapers:
       Studio:
         Name:
           fixed: Corbin Fisher
+      Tags:
+        Name:
+          selector: //head/link[@rel="canonical"]/@href
+          postProcess:
+            - replace:
+              - regex: .*-(remastered|REMASTERED)\..*
+                with: "Remaster,Re-Release"
+            - replace:
+              - regex: ^http.*
+                with: ""
+          split: ","
 
   performerScraper:
     performer:


### PR DESCRIPTION
Corbin Fisher does not provide tags on their site. However they recently have been releasing a remastered re-released series of videos- at least one per week. This tag can be inferred from the canonical url.

_Generated by an automatic template. Can be removed if not applicable._

## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [ ] performerByURL
- [ ] sceneByName
- [ ] sceneByQueryFragment
- [ ] sceneByFragment
- [x] sceneByURL
- [ ] groupByURL
- [ ] galleryByFragment
- [ ] galleryByURL
- [ ] imageByFragment
- [ ] imageByURL

## Examples to test

Tested against:
https://www.corbinfisher.com/tour/trailers/Ty-Fucks-Austin-REMASTERED.html
https://corbinfisher.com/tour/trailers/Josh-Fucks-Brody-remastered.html

Tested that it does _not_ incorrectly tag scenes without this regex in the url:
https://www.corbinfisher.com/tour/trailers/Double-Loading-Noahs-Arse.html

## Short description

Autotag remastered/re-released scenes on CF
